### PR TITLE
Add support for buckets and fix demo/live

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var websocketClient = require('ws');
-const EventEmitter = require('events');
+const { once, EventEmitter } = require('events');
 const axios = require('axios')
 
 
@@ -22,13 +22,13 @@ var transport = null;
 
 var ws = null;
 
-const wssUrl = 'wss://live.trading212.com/streaming/events/?app=WC4&appVersion=5.119.2&EIO=3&transport=websocket';
 
 class Trading212 extends EventEmitter {
-    constructor(ENV, CUSTOMER_SESSION, TRADING212_SESSION_LIVE) {
+    constructor(ENV, CUSTOMER_SESSION) {
         super();
+        const wssUrl = `wss://${ENV.toLowerCase()}.trading212.com/streaming/events/?app=WC4&appVersion=2.2.85&EIO=3&transport=websocket`;
 
-        baseUrl = "https://" + ENV + baseUrl;
+        baseUrl = "https://" + ENV.toLowerCase() + baseUrl;
 
         var headers = {
             "Accept": "application/json",
@@ -38,9 +38,8 @@ class Trading212 extends EventEmitter {
             "Sec-Fetch-Mode": "cors",
             "Sec-Fetch-Site": "same-origin",
             "Sec-GPC": 1,
-            "Referer": "https://live.trading212.com/",
             "Content-Type": "application/json",
-            Cookie: `CUSTOMER_SESSION=${CUSTOMER_SESSION}; TRADING212_SESSION_LIVE=${TRADING212_SESSION_LIVE}`
+            "Cookie": `CUSTOMER_SESSION=${CUSTOMER_SESSION}; TRADING212_SESSION_${ENV.toUpperCase()}=${CUSTOMER_SESSION}`
         }
 
         transport = axios.create({
@@ -65,16 +64,16 @@ class Trading212 extends EventEmitter {
         });
 
         ws.on('message', (data) => {
-            if(data == 3) {
+            if (data == 3) {
                 ws.send(2);
             }
 
-            if(data.substring(0, '42["platform-message-sync"'.length) == '42["platform-message-sync"') {
+            if (data.substring(0, '42["platform-message-sync"'.length) == '42["platform-message-sync"') {
                 this.subscribeRoute('WEBPLATFORM');
                 this.subscribeRoute('ACCOUNT');
                 ws.send('42["acc"]');
                 this.emit('platform-subscribed');
-            } else if(data.substring(0, '42["q"'.length) == '42["q"') {
+            } else if (data.substring(0, '42["q"'.length) == '42["q"') {
                 data = data.substring('42["q"'.length);
                 data = data.substring(2, data.length - 1);
                 data = data.split("|");
@@ -84,7 +83,7 @@ class Trading212 extends EventEmitter {
                     ask: data[2],
                 }
                 this.emit('price', data);
-            } else if(data.substring(0, '42["q-sync"'.length) == '42["q-sync"') {
+            } else if (data.substring(0, '42["q-sync"'.length) == '42["q-sync"') {
                 data = data.substring('42["q-sync"'.length);
                 data = data.substring(2, data.length - 1);
                 data = data.split("|");
@@ -94,81 +93,143 @@ class Trading212 extends EventEmitter {
                     ask: data[2],
                 }
                 this.emit('price', data);
-            } else if(data.substring(0, '42["working-schedule-sync"'.length) == '42["working-schedule-sync"') {
-               
-            } else if(data.substring(0, 9) == '42["acc",') {
+            } else if (data.substring(0, '42["working-schedule-sync"'.length) == '42["working-schedule-sync"') {
+
+            } else if (data.substring(0, 9) == '42["acc",') {
                 data = data.substring(9);
                 data = data.substring(0, data.length - 1);
                 data = JSON.parse(data);
                 this.emit('account', data);
-            } else if(data.substring(0, 12) == '42["acc-re",') {
+            } else if (data.substring(0, 12) == '42["acc-re",') {
                 data = data.substring(12);
                 data = data.substring(0, data.length - 1);
                 data = JSON.parse(data);
                 this.emit('reaccount', data);
+            } else if (data.substring(0, '42["buckets-sync",'.length) == '42["buckets-sync",') {
+                data = data.substring('42'.length);
+                data = JSON.parse(data);
+                this.emit('buckets', data[1]);
             } else {
-                //console.log(data);
+                console.log(data);
             }
         });
 
     }
 
     subscribeRoute(route) {
-        ws.send('42["subscribe","/'+route+'"]');
+        ws.send('42["subscribe","/' + route + '"]');
     }
 
     bulkSubscribe(ticker_symbols) {
         ticker_symbols = ticker_symbols.map(el => {
-            return '"'+el+'"';
+            return '"' + el + '"';
         });
-        ws.send('42["s-qbulk",['+ticker_symbols+']]');
+        ws.send('42["s-qbulk",[' + ticker_symbols + ']]');
     }
 
     bulkUnsubscribe(ticker_symbols) {
         ticker_symbols = ticker_symbols.map(el => {
-            return '"'+el+'"';
+            return '"' + el + '"';
         });
-        ws.send('42["us-qbulk",['+ticker_symbols+']]');
+        ws.send('42["us-qbulk",[' + ticker_symbols + ']]');
     }
 
     getCurrentPrice(instruments) {
         transport
-        .post(baseUrl + priceUrl, instruments).then(res => {
-            res.data.ticker = res.data.instrumentCode;
-            this.emit('price', res.data);
-        }).catch(err => {
-            console.log(err);
-        })
+            .post(baseUrl + priceUrl, instruments).then(res => {
+                res.data.ticker = res.data.instrumentCode;
+                this.emit('price', res.data);
+            }).catch(err => {
+                console.log(err);
+            })
+    }
+
+    getBuckets() {
+        this.subscribeRoute('BUCKETS');
+    }
+
+    async getBucketId(bucketName) {
+        this.subscribeRoute('BUCKETS');
+        const [response] = await once(this, 'buckets');
+
+        return response
+            .find(arr => arr.settings.name == bucketName)
+            .id;
+    }
+
+    fundBucket(bucketID, amount, distribution_type) {
+        transport
+            .get(baseUrl + `/rest/autoinvest/buckets/${bucketID}/fund?amount=${amount.toFixed(2)}&distributionType=${distribution_type}`)
+            .then(resGET => {
+                // Confirmed we can make the operation
+                this.emit('bucket-prefund', resGET.data);
+
+                let postData = {
+                    "amount": amount,
+                    "distributionType": distribution_type,
+                    "orders": resGET.data.buys,
+                }
+                transport
+                    .post(baseUrl + `/rest/autoinvest/buckets/${bucketID}/fund?distributionType=${distribution_type}`, postData)
+                    .then(res => {
+                        this.emit('bucket-funded', res.data);
+                    })
+                    .catch(err => { console.log(err) })
+
+            })
+            .catch(err => { console.log(err) })
     }
 
     getAvailableEquities() {
         transport
-        .get(baseUrl + availableEquitiesUrl)
-        .then(res => { this.emit('equity-data', res.data.items); } )
-        .catch(err => { console.log(err) })
+            .get(baseUrl + availableEquitiesUrl)
+            .then(res => { this.emit('equity-data', res.data.items); })
+            .catch(err => { console.log(err) })
     }
 
     getHotlist(period, delta) {
         transport
-        .get(hotListUrl + period + "/" + delta)
-        .then(res => { this.emit('hotlist', period, delta, res.data); } )
-        .catch(err => { console.log(err) })
+            .get(hotListUrl + period + "/" + delta)
+            .then(res => { this.emit('hotlist', period, delta, res.data); })
+            .catch(err => { console.log(err) })
     }
-    
+
     getExchangeRate() {
         axios.get('https://query2.finance.yahoo.com/v10/finance/quoteSummary/GBPUSD=X?modules=assetProfile%2CsummaryProfile%2CsummaryDetail%2CesgScores%2Cprice%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2CfinancialData%2CcalendarEvents%2CsecFilings%2CrecommendationTrend%2CupgradeDowngradeHistory%2CinstitutionOwnership%2CfundOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CinsiderTransactions%2CinsiderHolders%2CnetSharePurchaseActivity%2Cearnings%2CearningsHistory%2CearningsTrend%2CindustryTrend%2CindexTrend%2CsectorTrend')
-        .then(res => {
-            this.emit('forex', res.data);
-        }).catch(err => {
-            console.log(err);
-        });
+            .then(res => {
+                this.emit('forex', res.data);
+            }).catch(err => {
+                console.log(err);
+            });
         //
     }
 
     validateOrder(instrumentCode, orderType, stopPrice, limitPrice, quantity, timeValidity) {
         return new Promise(function (resolve, reject) {
             transport
-            .post(baseUrl + orderUrl + '/validate', {
+                .post(baseUrl + orderUrl + '/validate', {
+                    instrumentCode: instrumentCode,
+                    orderType: orderType,
+                    stopPrice: stopPrice,
+                    limitPrice: limitPrice,
+                    quantity: quantity,
+                    timeValidity: timeValidity,
+
+                }).then(res => {
+                    resolve('OK');
+                }).catch(err => {
+                    if (err.response.hasOwnProperty('data') && err.response.data.hasOwnProperty('message')) {
+                        reject(err.response.data.message);
+                    } else {
+                        reject("Unhandled error");
+                    }
+                })
+        });
+    }
+
+    placeOrder(instrumentCode, orderType, stopPrice, limitPrice, quantity, timeValidity) {
+        transport
+            .post(baseUrl + orderUrl, {
                 instrumentCode: instrumentCode,
                 orderType: orderType,
                 stopPrice: stopPrice,
@@ -177,50 +238,28 @@ class Trading212 extends EventEmitter {
                 timeValidity: timeValidity,
 
             }).then(res => {
-                resolve('OK');
-            }).catch(err => {
-                if(err.response.hasOwnProperty('data') && err.response.data.hasOwnProperty('message')) {
-                    reject(err.response.data.message);
+                if (res.hasOwnProperty("data") && res.data.hasOwnProperty("account")) {
+                    this.emit('account', res.data.account);
                 } else {
-                    reject("Unhandled error");
+                    this.emit('order-failure', res.data);
                 }
+            }).catch(err => {
+                console.log(err);
             })
-        });
-    }
-
-    placeOrder(instrumentCode, orderType, stopPrice, limitPrice, quantity, timeValidity) {
-        transport
-        .post(baseUrl + orderUrl, {
-            instrumentCode: instrumentCode,
-            orderType: orderType,
-            stopPrice: stopPrice,
-            limitPrice: limitPrice,
-            quantity: quantity,
-            timeValidity: timeValidity,
-
-        }).then(res => {
-            if(res.hasOwnProperty("data") && res.data.hasOwnProperty("account")) {
-                this.emit('account', res.data.account);
-            } else {
-                this.emit('order-failure', res.data);
-            }
-        }).catch(err => {
-            console.log(err);
-        })
     }
 
     deleteOrder(orderId) {
         console.log('trying to delete order');
         transport
-        .delete(baseUrl + orderUrl + '/' + orderId).then(res => {
-            if(res.hasOwnProperty("data") && res.data.hasOwnProperty("account")) {
-                this.emit('account', res.data);
-            } else {
-                this.emit('order-failure', res.data);
-            }
-        }).catch(err => {
-            console.log(err);
-        })
+            .delete(baseUrl + orderUrl + '/' + orderId).then(res => {
+                if (res.hasOwnProperty("data") && res.data.hasOwnProperty("account")) {
+                    this.emit('account', res.data);
+                } else {
+                    this.emit('order-failure', res.data);
+                }
+            }).catch(err => {
+                console.log(err);
+            })
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,24 +2,24 @@
 # yarn lockfile v1
 
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+"axios@^0.21.1":
+  "integrity" "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg=="
+  "resolved" "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz"
+  "version" "0.21.4"
   dependencies:
-    follow-redirects "^1.10.0"
+    "follow-redirects" "^1.14.0"
 
-events@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
-  integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
+"events@^3.2.0":
+  "integrity" "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+  "resolved" "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
+  "version" "3.3.0"
 
-follow-redirects@^1.10.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
-  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+"follow-redirects@^1.14.0":
+  "integrity" "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+  "resolved" "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
+  "version" "1.15.2"
 
-ws@^7.4.3:
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
-  integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
+"ws@^7.4.3":
+  "integrity" "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+  "resolved" "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
+  "version" "7.5.9"


### PR DESCRIPTION
Hello,

Thank you for this project! I'm glad that at least someone decided to use API and not as a full web motor.

I fixed the live/demo modes, implemented functions to get buckets info and emit a bucket fund. Also, reduced the constructor and did beautify with VScode.

A working example to fund a bucket:

```
const trading212Handler = require('trading212');

const LIVE_SESSION = "12341234-abcd-abcd-56785678";
const DEMO_SESSION = "12341234-abcd-abcd-56785678";

//Create handle and client
const trading212 = new trading212Handler('demo', DEMO_SESSION);


async function run() {
  return new Promise((resolve, reject) =>
    trading212
      .on('platform-subscribed', async () => {
        // trading212.getBuckets();
        let bucketID = await trading212.getBucketId("My xd AAA");

        trading212.fundBucket(bucketID, 15, "BY_TARGETS");

      })
      .on('bucket-funded', (output) => {
        console.log('Funded!:', output)
        resolve(output)
      })
  )
}


(async () => {
  await run();
  console.log("Bye Bye")
  // This is were you put your code
})();
```

Missing stuff (in my opinion):

- API call in the constructor to refresh cookies
- Use more enums instead strings (like the events names)

Hope it will be usueful :)